### PR TITLE
Helm version upgraded & colordiff utility added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ARG HELM_VERSION=v2.11.0
+ARG HELM_VERSION=v2.13.2
 ARG HELM_OS_ARCH=linux-amd64
 
 RUN apk --no-cache add ca-certificates git bash curl jq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.8
 ARG HELM_VERSION=v2.13.2
 ARG HELM_OS_ARCH=linux-amd64
 
-RUN apk --no-cache add ca-certificates git bash curl jq \
+RUN apk --no-cache add ca-certificates git bash curl jq colordiff \
   && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-${HELM_OS_ARCH}.tar.gz \
   && tar -zxvf helm-${HELM_VERSION}-${HELM_OS_ARCH}.tar.gz ${HELM_OS_ARCH}/helm \
   && mv ${HELM_OS_ARCH}/helm /usr/local/bin/helm \


### PR DESCRIPTION
Hi @maorfr,

First of all, I want to thank you for the great work you did (and still do!) with orca.
We at Bancor heavily rely on the amazing abilities of this great tool in our CI/CD system.

In this PR I upgraded the version of `Helm` to v2.13.2.
It's worth to mention that although there's a newer version of `Helm` at the time of creating this PR, it's seems that the newer version has a few annoying bugs 
(which hopefully will be resolved in the next versions of Helm v2) so for now the latest stable release of `Helm` is the v2.13.2 version.

In addition, I've added `colordiff` to the set of utilities that the orca's docker image offers.
The `colordiff` utility provides rich functionality and works better than the regular alpine diff utility.
I'm pretty sure that this addition will help others (among myself) to create better reporting abilities, for example, when trying to compare different environments created by orca.

Hope that you'll find those changes to the `master` branch useful.

Thanks,
Haim