### PR TITLE
Upgrade the base docker image to alpine:3.10.1 & downgrade to v2.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
-ARG HELM_VERSION=v2.13.2
+ARG HELM_VERSION=v2.13.1
 ARG HELM_OS_ARCH=linux-amd64
 
 RUN apk --no-cache add ca-certificates git bash curl jq colordiff \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10.1
 
 ARG HELM_VERSION=v2.13.1
 ARG HELM_OS_ARCH=linux-amd64


### PR DESCRIPTION
Hi @maorfr,

I've made a mistake in the last PR and upgrade the `Helm` version to v2.13.2 which is a version that I haven't tested yet, instead of upgrading to v2.13.1.

In addition, this PR suggests to use alpine:3.10.1 as a docker base image for orca. This version of Linux alpine introduces some security patches and some improvements to apk.

Thanks,
Haim

